### PR TITLE
Fix missaligned TextLayer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import React, {useEffect, useState} from 'react';
 import './App.css';
 import {Document, Page, pdfjs} from "react-pdf";
-
+import 'react-pdf/dist/esm/Page/TextLayer.css';
+import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
 pdfjs.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;
 
 function App() {


### PR DESCRIPTION
You mentioned a bug in https://github.com/wojtekmaj/react-pdf/issues/1292

It's not really a bug (well, missing warnings could be called a bug?) rather missing imports.